### PR TITLE
Fix linux compilation

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -194,7 +194,7 @@ void Vector3::parseFromText(const char* text, const char separator)
 			strncpy(num, start, current - start);
 			num[current - start] = '\0';
 			start = current + 1;
-			if (num[0] != 'x') //¿?
+			if (num[0] != 'x') //?
 				switch(pos)
 				{
 					case 0: x = (float)atof(num); break;
@@ -291,7 +291,7 @@ void Matrix44::transpose()
 
 Vector3 Matrix44::rotateVector(const Vector3& v)
 {
-	return (*this * Vector4(v,0.0)).xyz;
+	return (*this * Vector4(v,0.0)).sV4Data.xyz;
 }
 
 void Matrix44::translateGlobal(float x, float y, float z)
@@ -1290,7 +1290,7 @@ Vector3 RayPlaneCollision(const Vector3& plane_pos, const Vector3& plane_normal,
 
 int planeBoxOverlap( const Vector4& plane, const Vector3& center, const Vector3& halfsize )
 {
-	Vector3 n = plane.xyz;
+	Vector3 n = plane.sV4Data.xyz;
 	float d = plane.w;
 	float radius = abs(halfsize.x * n[0]) + abs(halfsize.y * n[1]) + abs(halfsize.z * n[2]);
 	float distance = dot(n, center) + d;
@@ -1310,7 +1310,7 @@ float computeAngleDiff( float a, float b )
 
 float signedDistanceToPlane( const Vector4& plane, const Vector3& point )
 {
-	return dot(plane.xyz, point) + plane.w;
+	return dot(plane.sV4Data.xyz, point) + plane.w;
 }
 
 const Vector3 corners[] = { {1,1,1},  {1,1,-1},  {1,-1,1},  {1,-1,-1},  {-1,1,1},  {-1,1,-1},  {-1,-1,1},  {-1,-1,-1} };

--- a/src/math.h
+++ b/src/math.h
@@ -159,11 +159,11 @@ public:
 	{
 		struct { float x,y,z; };
 		float v[3];
-		struct { Vector2 xy; } sV3Data;
+		struct { Vector2 xy; float _z; } sV3Data;
 	};
 
-	Vector3() : xy() { x = y = z = 0.0f; }
-	Vector3(float x, float y, float z) : xy() { this->x = x; this->y = y; this->z = z;	}
+	Vector3() { x = y = z = 0.0f; }
+	Vector3(float x, float y, float z) { this->x = x; this->y = y; this->z = z;	}
 
 	double length();
 	double length() const;
@@ -215,7 +215,7 @@ public:
 	{
 		struct { float x,y,z,w; };
 		float v[4];
-		struct { Vector3 xyz; float _w;  };
+		struct { Vector3 xyz; float _w; } sV4Data;
 	};
 
 	Vector4() { x = y = z = w = 0.0; }


### PR DESCRIPTION
We were using a feature that it's [not in the standard](https://stackoverflow.com/questions/41031424/constructor-not-allowed-in-anonymous-aggregate-string-in-struct). Added a name to the struct and now it compiles. I removed a random '¿' because it was broken in linux and github. I also added a _z component to Vector3 for consistency with Vector4 (and to match memory size of union).